### PR TITLE
included bootstrap css/js in search_head

### DIFF
--- a/resources/templates/search_head.php
+++ b/resources/templates/search_head.php
@@ -1,5 +1,9 @@
 <!-- Load scripts, styles, etc for search page here -->
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+
 <link rel="stylesheet" type="text/css" href="/resources/styles/search_styles.css">
 <link rel="stylesheet" type="text/css" href="/resources/styles/styles-footer.css">
 <link rel="stylesheet" type="text/css" href="/resources/styles/styles-header.css">


### PR DESCRIPTION
the fonts on the search page were different from the rest of the site
i realized that it was because bootstrap was not being used, so i included it 
im fairly certain that no functionality and no other style was affected, but given that i did not work on the search page and have not done much with bootstrap, i do not feel comfortable enough with this change to commit it without input from those who have worked on the things i mentioned